### PR TITLE
Renamed parameters in BAS webservice functions & fix related to race conditions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: emuR
-Version: 0.2.1.9009
+Version: 0.2.1.9010
 Title: Main Package of the EMU Speech Database Management System
 Authors@R: c(
     person("Raphael", "Winkelmann", , "raphael@phonetik.uni-muenchen.de", c("aut", "cre")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,13 @@
+# emuR 0.2.1.9010
+
+## new features / performance tweaks / improvements
+
+* some changes to the parameter names in the BAS webservice functions
+
+## bug fixes
+
+* BAS webservice calls now get their own temp directories (UUID based). This avoids race conditions when several scripts are running in parallel.
+
 # emuR 0.2.1.9009
 
 ## new features / performance tweaks / improvements

--- a/R/emuR-bas_webservices.R
+++ b/R/emuR-bas_webservices.R
@@ -32,19 +32,18 @@
 ##'
 ##' @param orthoAttributeDefinitionName attribute name for orthographic words
 ##' @param canoAttributeDefinitionName attribute name for canonical pronunciations of words
-##' @param chunkAttributeDefinitionName attribute name for the chunk segmentation
+##' @param chunkAttributeDefinitionName attribute name for the chunk segmentation.
 ##' Please note that the chunk segmentation will only be generated if your emuDB contains
 ##' audio files beyond the one minute mark.
 ##' @param mausAttributeDefinitionName attribute name for the MAUS segmentation
 ##' @param minniAttributeDefinitionName attribute name for the MINNI segmentation
-##' @param sylAttributeDefinitionName attributeDefinitionName name for syllable segmentation
+##' @param sylAttributeDefinitionName attribute name for syllable segmentation
 ##' @param canoSylAttributeDefinitionName attribute name for syllabified canonical pronunciations of words
 ##'
 ##' @param verbose Display progress bars and other information
 ##' @param resume If a previous call to this function has failed (and you think you have fixed the issue
 ##' that caused the error), you can set resume=TRUE to recover any progress made up to that point. This
-##' will only work if you have not run any other emuR functions (such as the query function or other
-##' webservice functions) in the meantime, as they are likely to delete your temporary data.
+##' will only work if your R temporary directory has not been deleted or emptied in the meantime.
 
 runBASwebservice_all <- function(handle,
                                  transcriptionAttributeDefinitionName,
@@ -234,7 +233,7 @@ runBASwebservice_all <- function(handle,
 ##' If this attribute resides on a segment level, the segment time information is used as a presegmentation.
 ##' If it is an item level, no assumption is made about the temporal position of segments.
 ##' @param chunkLevel if you have a chunk segmentation level, you can provide it to improve the speed and accuracy
-##' of MAUS. The chunk segmentation level must be a segment level, and it must link to the level of orthoAttributeDefinitionName.
+##' of MAUS. The chunk segmentation level must be a segment level, and it must link to the level of canoAttributeDefinitionName.
 ##' @param turnChunkLevelIntoItemLevel if TRUE, and if a chunk level is provided, the chunk level is converted into an ITEM level after segmentation
 ##' @param params named list of parameters to be passed on to the webservice. It is your own reponsibility to
 ##' ensure that these parameters are compatible with the webservice API
@@ -473,8 +472,8 @@ runBASwebservice_chunker <- function(handle,
 ##'
 ##' The MINNI phoneme decoder performs phoneme-based decoding on the signal without input from
 ##' the transcription. Therefore, labelling quality is usually worse than that obtained from
-##' MAUS (\link{runBASwebservice_maus}). Contrary to MAUS however, there is no need for a pre-
-##' existing transcription.
+##' MAUS (\link{runBASwebservice_maus}). Contrary to MAUS however, there is no need for a
+##' pre-existing transcription.
 ##'
 ##' All necessary level, link and attribute definitions are created in the process.
 ##'

--- a/R/emuR-bas_webservices.R
+++ b/R/emuR-bas_webservices.R
@@ -61,6 +61,7 @@ runBASwebservice_all <- function(handle,
                                  resume = FALSE,
                                  verbose = TRUE)
 {
+  func = "all"
   transcriptionLevel = get_levelNameForAttributeName(handle, transcriptionLabel)
   
   oldBasePath = handle$basePath
@@ -90,7 +91,7 @@ runBASwebservice_all <- function(handle,
     usetrn = "false"
   }
   
-  handle = bas_prepare(handle, resume, verbose)
+  handle = bas_prepare(handle, resume, verbose, func)
   
   bas_run_g2p_for_tokenization_dbi(
     handle = handle,
@@ -99,7 +100,8 @@ runBASwebservice_all <- function(handle,
     language = language,
     verbose = verbose,
     resume = resume,
-    params = list()
+    params = list(),
+    func = func
   )
   
   bas_run_g2p_for_pronunciation_dbi(
@@ -109,7 +111,8 @@ runBASwebservice_all <- function(handle,
     language = language,
     verbose = verbose,
     resume = resume,
-    params = list(embed = "maus")
+    params = list(embed = "maus"),
+    func = func
   )
   
   
@@ -127,7 +130,8 @@ runBASwebservice_all <- function(handle,
       verbose = verbose,
       language = language,
       oldBasePath = oldBasePath,
-      perspective = "default"
+      perspective = "default",
+      func = func
     )
   }
   
@@ -139,10 +143,11 @@ runBASwebservice_all <- function(handle,
     mausLabel = mausLabel,
     verbose = verbose,
     resume = resume,
-    params = list(USETRN=usetrn),
+    params = list(USETRN = usetrn),
     oldBasePath = oldBasePath,
     perspective = "default",
-    turnChunkLevelIntoItemLevel = T
+    turnChunkLevelIntoItemLevel = T,
+    func = func
   )
   
   bas_run_minni_dbi(
@@ -154,7 +159,8 @@ runBASwebservice_all <- function(handle,
     resume = resume,
     params = list(),
     oldBasePath = oldBasePath,
-    perspective = "default"
+    perspective = "default",
+    func = func
   )
   
   bas_run_pho2syl_canonical_dbi(
@@ -164,7 +170,8 @@ runBASwebservice_all <- function(handle,
     language = language,
     verbose = verbose,
     params = list(),
-    resume = resume
+    resume = resume,
+    func = func
   )
   
   bas_run_pho2syl_segmental_dbi(
@@ -175,7 +182,8 @@ runBASwebservice_all <- function(handle,
     superLabel = orthoLabel,
     resume = resume,
     params = list(wsync = "yes"),
-    verbose = verbose
+    verbose = verbose,
+    func = func
   )
   
   # remove the ORT -> MAU link as it is has been made redundant by the ORT -> MAS -> MAU path
@@ -190,7 +198,7 @@ runBASwebservice_all <- function(handle,
     # turn the chunk segmentation into an item level (as time information is now on the MAU tier)
     bas_segment_to_item_level(handle, chunkLabel)
     
-    # remove the transcription -> ORT link 
+    # remove the transcription -> ORT link
     # as it has been made redundant by the transcription -> TRN -> ORT path
     remove_linkDefinition(handle,
                           transcriptionLevel,
@@ -199,7 +207,7 @@ runBASwebservice_all <- function(handle,
                           verbose = F)
   }
   
-  handle = bas_clear(handle, oldBasePath)
+  handle = bas_clear(handle, oldBasePath, func)
   rewrite_allAnnots(handle, verbose = verbose)
 }
 
@@ -247,8 +255,9 @@ runBASwebservice_maus <- function(handle,
                                   resume = FALSE,
                                   verbose = TRUE)
 {
+  func = "maus"
   oldBasePath = handle$basePath
-  handle = bas_prepare(handle, resume, verbose)
+  handle = bas_prepare(handle, resume, verbose, func)
   
   bas_run_maus_dbi(
     handle = handle,
@@ -261,10 +270,11 @@ runBASwebservice_maus <- function(handle,
     params = params,
     oldBasePath = oldBasePath,
     perspective = perspective,
-    turnChunkLevelIntoItemLevel = turnChunkLevelIntoItemLevel
+    turnChunkLevelIntoItemLevel = turnChunkLevelIntoItemLevel,
+    func = func
   )
   
-  handle = bas_clear(handle, oldBasePath)
+  handle = bas_clear(handle, oldBasePath, func)
   
   rewrite_allAnnots(handle, verbose = verbose)
 }
@@ -301,8 +311,9 @@ runBASwebservice_g2pForTokenization <- function(handle,
                                                 resume = FALSE,
                                                 verbose = TRUE)
 {
+  func = "g2p_tokenization"
   oldBasePath = handle$basePath
-  handle = bas_prepare(handle, resume, verbose)
+  handle = bas_prepare(handle, resume, verbose, func)
   
   bas_run_g2p_for_tokenization_dbi(
     handle = handle,
@@ -311,10 +322,11 @@ runBASwebservice_g2pForTokenization <- function(handle,
     language = language,
     verbose = verbose,
     resume = resume,
-    params = params
+    params = params,
+    func = func
   )
   
-  handle = bas_clear(handle, oldBasePath)
+  handle = bas_clear(handle, oldBasePath, func)
   
   rewrite_allAnnots(handle, verbose = verbose)
 }
@@ -351,8 +363,9 @@ runBASwebservice_g2pForPronunciation <- function(handle,
                                                  resume = FALSE,
                                                  verbose = TRUE)
 {
+  func = "g2p_pronunciation"
   oldBasePath = handle$basePath
-  handle = bas_prepare(handle, resume, verbose)
+  handle = bas_prepare(handle, resume, verbose, func)
   
   bas_run_g2p_for_pronunciation_dbi(
     handle = handle,
@@ -361,10 +374,11 @@ runBASwebservice_g2pForPronunciation <- function(handle,
     canoLabel = canoLabel,
     verbose = verbose,
     resume = resume,
-    params = params
+    params = params,
+    func = func
   )
   
-  handle = bas_clear(handle, oldBasePath)
+  handle = bas_clear(handle, oldBasePath, func)
   
   rewrite_allAnnots(handle, verbose = verbose)
 }
@@ -418,8 +432,9 @@ runBASwebservice_chunker <- function(handle,
                                      resume = FALSE,
                                      verbose = TRUE)
 {
+  func = "chunker"
   oldBasePath = handle$basePath
-  handle = bas_prepare(handle, resume, verbose)
+  handle = bas_prepare(handle, resume, verbose, func)
   
   bas_run_chunker_dbi(
     handle = handle,
@@ -432,10 +447,11 @@ runBASwebservice_chunker <- function(handle,
     oldBasePath = oldBasePath,
     perspective = perspective,
     resume = resume,
-    rootLabel = rootLabel
+    rootLabel = rootLabel,
+    func = func
   )
   
-  handle = bas_clear(handle, oldBasePath)
+  handle = bas_clear(handle, oldBasePath, func)
   
   rewrite_allAnnots(handle, verbose = verbose)
 }
@@ -477,8 +493,9 @@ runBASwebservice_minni <- function(handle,
                                    resume = FALSE,
                                    verbose = TRUE)
 {
+  func = "minni"
   oldBasePath = handle$basePath
-  handle = bas_prepare(handle, resume, verbose)
+  handle = bas_prepare(handle, resume, verbose, func)
   
   bas_run_minni_dbi(
     handle = handle,
@@ -489,10 +506,11 @@ runBASwebservice_minni <- function(handle,
     resume = resume,
     params = params,
     oldBasePath = oldBasePath,
-    perspective = perspective
+    perspective = perspective,
+    func = func
   )
   
-  handle = bas_clear(handle, oldBasePath)
+  handle = bas_clear(handle, oldBasePath, func)
   
   rewrite_allAnnots(handle, verbose = verbose)
 }
@@ -526,8 +544,9 @@ runBASwebservice_pho2sylCanonical <- function(handle,
                                               resume = FALSE,
                                               verbose = TRUE)
 {
+  func = "pho2syl_canonical"
   oldBasePath = handle$basePath
-  handle = bas_prepare(handle, resume, verbose)
+  handle = bas_prepare(handle, resume, verbose, func)
   
   bas_run_pho2syl_canonical_dbi(
     handle = handle,
@@ -536,11 +555,12 @@ runBASwebservice_pho2sylCanonical <- function(handle,
     verbose = verbose,
     canoSylLabel = canoSylLabel,
     resume = resume,
-    params = params
+    params = params,
+    func = func
   )
   
   
-  handle = bas_clear(handle, oldBasePath)
+  handle = bas_clear(handle, oldBasePath, func)
   
   rewrite_allAnnots(handle, verbose = verbose)
 }
@@ -582,8 +602,9 @@ runBASwebservice_pho2sylSegmental <- function(handle,
                                               resume = FALSE,
                                               verbose = TRUE)
 {
+  func = "pho2syl_segmental"
   oldBasePath = handle$basePath
-  handle = bas_prepare(handle, resume, verbose)
+  handle = bas_prepare(handle, resume, verbose, func)
   
   bas_run_pho2syl_segmental_dbi(
     handle = handle,
@@ -593,11 +614,12 @@ runBASwebservice_pho2sylSegmental <- function(handle,
     sylLabel = sylLabel,
     superLabel = superLabel,
     resume = resume,
-    params = params
+    params = params,
+    func = func
   )
   
   
-  handle = bas_clear(handle, oldBasePath)
+  handle = bas_clear(handle, oldBasePath, func)
   
   rewrite_allAnnots(handle, verbose = verbose)
 }

--- a/R/emuR-bas_webservices.R
+++ b/R/emuR-bas_webservices.R
@@ -23,22 +23,22 @@
 ##'
 ##' @export
 ##' @param handle emuDB handle
-##' @param transcriptionLabel name of the label (not level!) containing an orthographic transcription.
+##' @param transcriptionAttributeDefinitionName name of the attribute (not level!) containing an orthographic transcription.
 ##' @param language language(s) to be used. If you pass a single string (e.g. "deu-DE"), this language will be used for all bundles.
 ##' Alternatively, you can select the language for every bundle individually. To do so, you must pass a data frame with the columns
 ##' session, bundle, language. This data frame must contain one row for every bundle in your emuDB.
 ##' Up-to-date lists of the languages accepted by all webservices can be found here:
 ##' \url{https://clarin.phonetik.uni-muenchen.de/BASWebServices/services/help}
 ##'
-##' @param orthoLabel label name for orthographic words
-##' @param canoLabel label name for canonical pronunciations of words
-##' @param chunkLabel label name for the chunk segmentation
+##' @param orthoAttributeDefinitionName attribute name for orthographic words
+##' @param canoAttributeDefinitionName attribute name for canonical pronunciations of words
+##' @param chunkAttributeDefinitionName attribute name for the chunk segmentation
 ##' Please note that the chunk segmentation will only be generated if your emuDB contains
 ##' audio files beyond the one minute mark.
-##' @param mausLabel label name for the MAUS segmentation
-##' @param minniLabel label name for the MINNI segmentation
-##' @param sylLabel label name for syllable segmentation
-##' @param canoSylLabel label name for syllabified canonical pronunciations of words
+##' @param mausAttributeDefinitionName attribute name for the MAUS segmentation
+##' @param minniAttributeDefinitionName attribute name for the MINNI segmentation
+##' @param sylAttributeDefinitionName attributeDefinitionName name for syllable segmentation
+##' @param canoSylAttributeDefinitionName attribute name for syllabified canonical pronunciations of words
 ##'
 ##' @param verbose Display progress bars and other information
 ##' @param resume If a previous call to this function has failed (and you think you have fixed the issue
@@ -47,47 +47,48 @@
 ##' webservice functions) in the meantime, as they are likely to delete your temporary data.
 
 runBASwebservice_all <- function(handle,
-                                 transcriptionLabel,
+                                 transcriptionAttributeDefinitionName,
                                  language,
                                  
-                                 orthoLabel = "ORT",
-                                 canoLabel = "KAN",
-                                 mausLabel = "MAU",
-                                 minniLabel = "MINNI",
-                                 sylLabel = "MAS",
-                                 canoSylLabel = "KAS",
-                                 chunkLabel = "TRN",
+                                 orthoAttributeDefinitionName = "ORT",
+                                 canoAttributeDefinitionName = "KAN",
+                                 mausAttributeDefinitionName = "MAU",
+                                 minniAttributeDefinitionName = "MINNI",
+                                 sylAttributeDefinitionName = "MAS",
+                                 canoSylAttributeDefinitionName = "KAS",
+                                 chunkAttributeDefinitionName = "TRN",
                                  
                                  resume = FALSE,
                                  verbose = TRUE)
 {
   func = "all"
-  transcriptionLevel = get_levelNameForAttributeName(handle, transcriptionLabel)
+  transcriptionLevel = get_levelNameForAttributeName(handle, transcriptionAttributeDefinitionName)
   
   oldBasePath = handle$basePath
   
   if (is.null(transcriptionLevel)) {
-    stop("Could not find a level for label ", transcriptionLabel)
+    stop("Could not find a level for attribute ", transcriptionAttributeDefinitionName)
   }
   
   running_chunker = FALSE
+  chunkLevel = NULL
   
   # if our transcription is a segment level, we assume it is a manual chunk segmentation
   if (get_levelDefinition(handle, transcriptionLevel)$type == "SEGMENT") {
-    chunkLabel = transcriptionLabel # the transcription is the chunk segmentation
+    chunkLevel = transcriptionLevel # the transcription is the chunk segmentation
     usetrn = "true" # we use it for MAUS
   }
   
   # else, we check if we will need to perform automatic chunk segmentation
   else if (bas_long_enough_for_chunker(handle, oldBasePath)) {
     running_chunker = TRUE # we need to run the chunker
-    chunkLevel = chunkLabel
+    chunkLevel = chunkAttributeDefinitionName
     usetrn = "true" # the to-be-created chunk segmentation will be used for MAUS
   }
   
   else
   {
-    chunkLabel = NULL
+    chunkAttributeDefinitionName = NULL
     usetrn = "false"
   }
   
@@ -95,8 +96,8 @@ runBASwebservice_all <- function(handle,
   
   bas_run_g2p_for_tokenization_dbi(
     handle = handle,
-    transcriptionLabel = transcriptionLabel,
-    orthoLabel = orthoLabel,
+    transcriptionAttributeDefinitionName = transcriptionAttributeDefinitionName,
+    orthoAttributeDefinitionName = orthoAttributeDefinitionName,
     language = language,
     verbose = verbose,
     resume = resume,
@@ -106,8 +107,8 @@ runBASwebservice_all <- function(handle,
   
   bas_run_g2p_for_pronunciation_dbi(
     handle = handle,
-    orthoLabel = orthoLabel,
-    canoLabel = canoLabel,
+    orthoAttributeDefinitionName = orthoAttributeDefinitionName,
+    canoAttributeDefinitionName = canoAttributeDefinitionName,
     language = language,
     verbose = verbose,
     resume = resume,
@@ -121,10 +122,10 @@ runBASwebservice_all <- function(handle,
   {
     bas_run_chunker_dbi(
       handle = handle,
-      canoLabel = canoLabel,
-      chunkLabel = chunkLabel,
-      orthoLabel = orthoLabel,
-      rootLabel = transcriptionLabel,
+      canoAttributeDefinitionName = canoAttributeDefinitionName,
+      chunkAttributeDefinitionName = chunkAttributeDefinitionName,
+      orthoAttributeDefinitionName = orthoAttributeDefinitionName,
+      rootLevel = transcriptionLevel,
       params = list(force = "rescue"),
       resume = resume,
       verbose = verbose,
@@ -137,10 +138,10 @@ runBASwebservice_all <- function(handle,
   
   bas_run_maus_dbi(
     handle = handle,
-    canoLabel = canoLabel,
+    canoAttributeDefinitionName = canoAttributeDefinitionName,
     language = language,
-    chunkLabel = chunkLabel,
-    mausLabel = mausLabel,
+    chunkLevel = chunkLevel,
+    mausAttributeDefinitionName = mausAttributeDefinitionName,
     verbose = verbose,
     resume = resume,
     params = list(USETRN = usetrn),
@@ -153,8 +154,8 @@ runBASwebservice_all <- function(handle,
   bas_run_minni_dbi(
     handle = handle,
     language = language,
-    minniLabel = minniLabel,
-    rootLabel = transcriptionLabel,
+    minniAttributeDefinitionName = minniAttributeDefinitionName,
+    rootLevel = transcriptionLevel,
     verbose = verbose,
     resume = resume,
     params = list(),
@@ -165,8 +166,8 @@ runBASwebservice_all <- function(handle,
   
   bas_run_pho2syl_canonical_dbi(
     handle = handle,
-    canoLabel = canoLabel,
-    canoSylLabel = canoSylLabel,
+    canoAttributeDefinitionName = canoAttributeDefinitionName,
+    canoSylAttributeDefinitionName = canoSylAttributeDefinitionName,
     language = language,
     verbose = verbose,
     params = list(),
@@ -174,35 +175,40 @@ runBASwebservice_all <- function(handle,
     func = func
   )
   
+  orthoLevel = orthoAttributeDefinitionName
+  
   bas_run_pho2syl_segmental_dbi(
     handle = handle,
-    segmentLabel = mausLabel,
+    segmentAttributeDefinitionName = mausAttributeDefinitionName,
     language = language,
-    sylLabel = sylLabel,
-    superLabel = orthoLabel,
+    sylAttributeDefinitionName = sylAttributeDefinitionName,
+    superLevel = orthoLevel,
     resume = resume,
     params = list(wsync = "yes"),
     verbose = verbose,
     func = func
   )
   
+  
+  mausLevel = mausAttributeDefinitionName
+  
   # remove the ORT -> MAU link as it is has been made redundant by the ORT -> MAS -> MAU path
   remove_linkDefinition(handle,
-                        orthoLabel,
-                        mausLabel,
+                        orthoLevel,
+                        mausLevel,
                         force = T,
                         verbose = F)
   
   if (running_chunker)
   {
     # turn the chunk segmentation into an item level (as time information is now on the MAU tier)
-    bas_segment_to_item_level(handle, chunkLabel)
+    bas_segment_to_item_level(handle, chunkLevel)
     
     # remove the transcription -> ORT link
     # as it has been made redundant by the transcription -> TRN -> ORT path
     remove_linkDefinition(handle,
                           transcriptionLevel,
-                          orthoLabel,
+                          orthoAttributeDefinitionName,
                           force = T,
                           verbose = F)
   }
@@ -224,11 +230,11 @@ runBASwebservice_all <- function(handle,
 ##'
 ##' @export
 ##'
-##' @param canoLabel name of the label (not level!) containing the SAMPA word pronunciations.
-##' If this label resides on a segment level, the segment time information is used as a presegmentation.
+##' @param canoAttributeDefinitionName name of the attribute (not level!) containing the SAMPA word pronunciations.
+##' If this attribute resides on a segment level, the segment time information is used as a presegmentation.
 ##' If it is an item level, no assumption is made about the temporal position of segments.
-##' @param chunkLabel if you have a chunk segmentation level, you can provide one of its labels to improve the speed and accuracy
-##' of MAUS. The chunk segmentation level must be a segment level, and it must link to the level of orthoLabel.
+##' @param chunkLevel if you have a chunk segmentation level, you can provide it to improve the speed and accuracy
+##' of MAUS. The chunk segmentation level must be a segment level, and it must link to the level of orthoAttributeDefinitionName.
 ##' @param turnChunkLevelIntoItemLevel if TRUE, and if a chunk level is provided, the chunk level is converted into an ITEM level after segmentation
 ##' @param params named list of parameters to be passed on to the webservice. It is your own reponsibility to
 ##' ensure that these parameters are compatible with the webservice API
@@ -241,12 +247,12 @@ runBASwebservice_all <- function(handle,
 ##' @inheritParams runBASwebservice_all
 
 runBASwebservice_maus <- function(handle,
-                                  canoLabel,
+                                  canoAttributeDefinitionName,
                                   language,
                                   
-                                  mausLabel = "MAU",
+                                  mausAttributeDefinitionName = "MAU",
                                   
-                                  chunkLabel = NULL,
+                                  chunkLevel = NULL,
                                   turnChunkLevelIntoItemLevel = TRUE,
                                   
                                   params = NULL,
@@ -261,10 +267,10 @@ runBASwebservice_maus <- function(handle,
   
   bas_run_maus_dbi(
     handle = handle,
-    canoLabel = canoLabel,
-    mausLabel = mausLabel,
+    canoAttributeDefinitionName = canoAttributeDefinitionName,
+    mausAttributeDefinitionName = mausAttributeDefinitionName,
     language = language,
-    chunkLabel = chunkLabel,
+    chunkLevel = chunkLevel,
     verbose = verbose,
     resume = resume,
     params = params,
@@ -301,10 +307,10 @@ runBASwebservice_maus <- function(handle,
 ##' @inheritParams runBASwebservice_all
 
 runBASwebservice_g2pForTokenization <- function(handle,
-                                                transcriptionLabel,
+                                                transcriptionAttributeDefinitionName,
                                                 language,
                                                 
-                                                orthoLabel = "ORT",
+                                                orthoAttributeDefinitionName = "ORT",
                                                 
                                                 params = list(),
                                                 
@@ -317,8 +323,8 @@ runBASwebservice_g2pForTokenization <- function(handle,
   
   bas_run_g2p_for_tokenization_dbi(
     handle = handle,
-    transcriptionLabel = transcriptionLabel,
-    orthoLabel = orthoLabel,
+    transcriptionAttributeDefinitionName = transcriptionAttributeDefinitionName,
+    orthoAttributeDefinitionName = orthoAttributeDefinitionName,
     language = language,
     verbose = verbose,
     resume = resume,
@@ -331,9 +337,9 @@ runBASwebservice_g2pForTokenization <- function(handle,
   rewrite_allAnnots(handle, verbose = verbose)
 }
 
-##' Creates canonical pronunciation labels for a tier of tokenized orthographical words.
+##' Creates canonical pronunciation attributes for a tier of tokenized orthographical words.
 ##'
-##' This function calls the G2P webservice to add canonical pronunciation labels in SAMPA (default)
+##' This function calls the G2P webservice to add canonical pronunciation attributes in SAMPA (default)
 ##' or IPA to a tier of tokenized orthographical words. It is usually called after tokenization
 ##' with \link{runBASwebservice_g2pForTokenization}. Its output can be used as input to
 ##' \link{runBASwebservice_maus} or \link{runBASwebservice_chunker}.
@@ -346,17 +352,17 @@ runBASwebservice_g2pForTokenization <- function(handle,
 ##' @family BAS webservice functions
 ##' @export
 ##'
-##' @param orthoLabel name of a label (not level!) containing orthographic words.
+##' @param orthoAttributeDefinitionName name of a attribute (not level!) containing orthographic words.
 ##'
 ##' @inheritParams runBASwebservice_all
 ##' @inheritParams runBASwebservice_maus
 
 
 runBASwebservice_g2pForPronunciation <- function(handle,
-                                                 orthoLabel,
+                                                 orthoAttributeDefinitionName,
                                                  language,
                                                  
-                                                 canoLabel = "KAN",
+                                                 canoAttributeDefinitionName = "KAN",
                                                  
                                                  params = list(embed = "maus"),
                                                  
@@ -369,9 +375,9 @@ runBASwebservice_g2pForPronunciation <- function(handle,
   
   bas_run_g2p_for_pronunciation_dbi(
     handle = handle,
-    orthoLabel = orthoLabel,
+    orthoAttributeDefinitionName = orthoAttributeDefinitionName,
     language = language,
-    canoLabel = canoLabel,
+    canoAttributeDefinitionName = canoAttributeDefinitionName,
     verbose = verbose,
     resume = resume,
     params = params,
@@ -394,7 +400,7 @@ runBASwebservice_g2pForPronunciation <- function(handle,
 ##' When audio input files are longer than approximately 10 minutes, alignment-based segmentation
 ##' tools such as MAUS will take a long time to run. In these cases, the Chunker pre-segments
 ##' the input into more digestable "chunks". As input, it requires a word tier with canonical
-##' pronunciation labels (which can be derived by \link{runBASwebservice_g2pForPronunciation}).
+##' pronunciation attributes (which can be derived by \link{runBASwebservice_g2pForPronunciation}).
 ##' The resulting chunk level can be passed as input to \link{runBASwebservice_maus}.
 ##' \strong{This function requires an internet connection.}
 ##'
@@ -409,22 +415,22 @@ runBASwebservice_g2pForPronunciation <- function(handle,
 ##' @family BAS webservice functions
 ##'
 ##' @export
-##' @param canoLabel name of the label (not level!) containing a canonical pronunciation of the words.
-##' @param rootLabel if provided, the new level will be linked to the root level
-##' @param orthoLabel if provided, chunk labels will contain orthographic instead of SAMPA strings.
-##' Must be paired with the canonical pronunciation labels in canoLabel.
-##' @param chunkLabel label name for the chunk segmentation
+##' @param canoAttributeDefinitionName name of the attribute (not level!) containing a canonical pronunciation of the words.
+##' @param rootLevel if provided, the new level will be linked to the root level
+##' @param orthoAttributeDefinitionName if provided, chunk attributes will contain orthographic instead of SAMPA strings.
+##' Must be paired with the canonical pronunciation attributes in canoAttributeDefinitionName.
+##' @param chunkAttributeDefinitionName attribute name for the chunk segmentation
 ##'
 ##' @inheritParams runBASwebservice_all
 ##' @inheritParams runBASwebservice_maus
 
 runBASwebservice_chunker <- function(handle,
-                                     canoLabel,
+                                     canoAttributeDefinitionName,
                                      language,
                                      
-                                     chunkLabel = "TRN",
-                                     rootLabel = NULL,
-                                     orthoLabel = NULL,
+                                     chunkAttributeDefinitionName = "TRN",
+                                     rootLevel = NULL,
+                                     orthoAttributeDefinitionName = NULL,
                                      
                                      params = list(force = "rescue"),
                                      
@@ -438,16 +444,16 @@ runBASwebservice_chunker <- function(handle,
   
   bas_run_chunker_dbi(
     handle = handle,
-    canoLabel = canoLabel,
-    chunkLabel = chunkLabel,
-    orthoLabel = orthoLabel,
+    canoAttributeDefinitionName = canoAttributeDefinitionName,
+    chunkAttributeDefinitionName = chunkAttributeDefinitionName,
+    orthoAttributeDefinitionName = orthoAttributeDefinitionName,
     language = language,
     verbose = verbose,
     params = params,
     oldBasePath = oldBasePath,
     perspective = perspective,
     resume = resume,
-    rootLabel = rootLabel,
+    rootLevel = rootLevel,
     func = func
   )
   
@@ -484,8 +490,8 @@ runBASwebservice_chunker <- function(handle,
 runBASwebservice_minni <- function(handle,
                                    language,
                                    
-                                   minniLabel = "MINNI",
-                                   rootLabel = NULL,
+                                   minniAttributeDefinitionName = "MINNI",
+                                   rootLevel = NULL,
                                    
                                    params = list(),
                                    
@@ -500,9 +506,9 @@ runBASwebservice_minni <- function(handle,
   bas_run_minni_dbi(
     handle = handle,
     language = language,
-    minniLabel = minniLabel,
+    minniAttributeDefinitionName = minniAttributeDefinitionName,
     verbose = verbose,
-    rootLabel = rootLabel,
+    rootLevel = rootLevel,
     resume = resume,
     params = params,
     oldBasePath = oldBasePath,
@@ -520,24 +526,24 @@ runBASwebservice_minni <- function(handle,
 ########################### PHO2SYL #################################
 #####################################################################
 
-##' Adds syllabified word labels to a word level that already contains a canonical pronunciation label.
+##' Adds syllabified word labels to a word level that already contains canonical pronunciations.
 ##'
-##' This function calls the webservice Pho2Syl to add a syllabified canonical pronunciation label
-##' to a word level that already contains an unsyllabified canonical pronunciation label (as can be
+##' This function calls the webservice Pho2Syl to add syllabified canonical pronunciation labels
+##' to a word level that already contains unsyllabified canonical pronunciation labels (as can be
 ##' derived using \link{runBASwebservice_g2pForPronunciation}). \strong{This function requires an internet
 ##' connection.}
 ##'
 ##' @family BAS webservice functions
 ##' @export
-##' @param canoLabel name of the label (not level!) containing a canonical pronunciation of the words.
+##' @param canoAttributeDefinitionName name of the attribute (not level!) containing a canonical pronunciation of the words.
 ##'
 ##' @inheritParams runBASwebservice_all
 ##' @inheritParams runBASwebservice_maus
 
 runBASwebservice_pho2sylCanonical <- function(handle,
-                                              canoLabel,
+                                              canoAttributeDefinitionName,
                                               language,
-                                              canoSylLabel = "KAS",
+                                              canoSylAttributeDefinitionName = "KAS",
                                               
                                               params = list(),
                                               
@@ -550,10 +556,10 @@ runBASwebservice_pho2sylCanonical <- function(handle,
   
   bas_run_pho2syl_canonical_dbi(
     handle = handle,
-    canoLabel = canoLabel,
+    canoAttributeDefinitionName = canoAttributeDefinitionName,
     language = language,
     verbose = verbose,
-    canoSylLabel = canoSylLabel,
+    canoSylAttributeDefinitionName = canoSylAttributeDefinitionName,
     resume = resume,
     params = params,
     func = func
@@ -570,8 +576,8 @@ runBASwebservice_pho2sylCanonical <- function(handle,
 ##'
 ##' This function calls the BAS webservice Pho2Syl to create a syllable segmentation on the basis
 ##' of a phonetic segmentation (created by, for example, \link{runBASwebservice_maus}).
-##' You can provide the name of your word segmentation, or of any other hierarchically
-##' dominant segmentation, via the superLabel parameter. This way, the new syllable
+##' You can provide the level of your word segmentation, or of any other hierarchically
+##' dominant segmentation, via the superLevel parameter. This way, the new syllable
 ##' items can be linked up into the pre-existing hierarchy. If you do not provide
 ##' this input, the syllables will only be linked down to the segments.
 ##'
@@ -581,20 +587,20 @@ runBASwebservice_pho2sylCanonical <- function(handle,
 ##'
 ##' @family BAS webservice functions
 ##' @export
-##' @param segmentLabel name of the label (not level!) containing a phonetic segmentation.
-##' @param superLabel name of a label on the segments' parent level (typically words).
+##' @param segmentAttributeDefinitionName name of the attribute (not level!) containing a phonetic segmentation.
+##' @param superLevel name of the segments' parent level (typically the word level).
 ##' If set to NULL, the syllable level cannot be linked up.
 ##'
 ##' @inheritParams runBASwebservice_all
 ##' @inheritParams runBASwebservice_maus
 
 runBASwebservice_pho2sylSegmental <- function(handle,
-                                              segmentLabel,
+                                              segmentAttributeDefinitionName,
                                               language,
                                               
-                                              superLabel = NULL,
+                                              superLevel = NULL,
                                               
-                                              sylLabel = "MAS",
+                                              sylAttributeDefinitionName = "MAS",
                                               
                                               params = list(wsync = "yes"),
                                               
@@ -608,11 +614,11 @@ runBASwebservice_pho2sylSegmental <- function(handle,
   
   bas_run_pho2syl_segmental_dbi(
     handle = handle,
-    segmentLabel = segmentLabel,
+    segmentAttributeDefinitionName = segmentAttributeDefinitionName,
     language = language,
     verbose = verbose,
-    sylLabel = sylLabel,
-    superLabel = superLabel,
+    sylAttributeDefinitionName = sylAttributeDefinitionName,
+    superLevel = superLevel,
     resume = resume,
     params = params,
     func = func

--- a/R/emuR-bas_webservicesDBI.R
+++ b/R/emuR-bas_webservicesDBI.R
@@ -2434,6 +2434,16 @@ bas_curl <- function(service, params)
 bas_paste_description <-
   function(description, source, service, params)
   {
+    # TODO: replace BASWebServicesTest with BASWebServices when Thomas (Kisler) says its okay
+    version = RCurl::getURL(
+      paste0(
+        "https://clarin.phonetik.uni-muenchen.de/BASWebServicesTest/services/runGetVersion?service=",
+        service
+      ),
+      .opts = RCurl::curlOptions(connecttimeout = 10, timeout = 30)
+    )
+    
+    version = stringr::str_trim(version)
     description = paste0(description, " automatically derived ")
     if (!is.null(source))
     {
@@ -2443,10 +2453,7 @@ bas_paste_description <-
       paste0(
         description,
         "by BAS webservice ",
-        service,
-        " (https://clarin.phonetik.uni-muenchen.de/BASWebServices/services/",
-        service,
-        ") on ",
+        service, " (", version, "), on ",
         Sys.time(),
         ", with the following parameters: (",
         paste0(c(rbind(

--- a/man/runBASwebservice_all.Rd
+++ b/man/runBASwebservice_all.Rd
@@ -4,15 +4,18 @@
 \alias{runBASwebservice_all}
 \title{Runs several BAS webservices, starting from an orthographic transcription}
 \usage{
-runBASwebservice_all(handle, transcriptionLabel, language, orthoLabel = "ORT",
-  canoLabel = "KAN", mausLabel = "MAU", minniLabel = "MINNI",
-  sylLabel = "MAS", canoSylLabel = "KAS", chunkLabel = "TRN",
-  resume = FALSE, verbose = TRUE)
+runBASwebservice_all(handle, transcriptionAttributeDefinitionName, language,
+  orthoAttributeDefinitionName = "ORT", canoAttributeDefinitionName = "KAN",
+  mausAttributeDefinitionName = "MAU",
+  minniAttributeDefinitionName = "MINNI",
+  sylAttributeDefinitionName = "MAS",
+  canoSylAttributeDefinitionName = "KAS",
+  chunkAttributeDefinitionName = "TRN", resume = FALSE, verbose = TRUE)
 }
 \arguments{
 \item{handle}{emuDB handle}
 
-\item{transcriptionLabel}{name of the label (not level!) containing an orthographic transcription.}
+\item{transcriptionAttributeDefinitionName}{name of the attribute (not level!) containing an orthographic transcription.}
 
 \item{language}{language(s) to be used. If you pass a single string (e.g. "deu-DE"), this language will be used for all bundles.
 Alternatively, you can select the language for every bundle individually. To do so, you must pass a data frame with the columns
@@ -20,26 +23,25 @@ session, bundle, language. This data frame must contain one row for every bundle
 Up-to-date lists of the languages accepted by all webservices can be found here:
 \url{https://clarin.phonetik.uni-muenchen.de/BASWebServices/services/help}}
 
-\item{orthoLabel}{label name for orthographic words}
+\item{orthoAttributeDefinitionName}{attribute name for orthographic words}
 
-\item{canoLabel}{label name for canonical pronunciations of words}
+\item{canoAttributeDefinitionName}{attribute name for canonical pronunciations of words}
 
-\item{mausLabel}{label name for the MAUS segmentation}
+\item{mausAttributeDefinitionName}{attribute name for the MAUS segmentation}
 
-\item{minniLabel}{label name for the MINNI segmentation}
+\item{minniAttributeDefinitionName}{attribute name for the MINNI segmentation}
 
-\item{sylLabel}{label name for syllable segmentation}
+\item{sylAttributeDefinitionName}{attribute name for syllable segmentation}
 
-\item{canoSylLabel}{label name for syllabified canonical pronunciations of words}
+\item{canoSylAttributeDefinitionName}{attribute name for syllabified canonical pronunciations of words}
 
-\item{chunkLabel}{label name for the chunk segmentation
+\item{chunkAttributeDefinitionName}{attribute name for the chunk segmentation.
 Please note that the chunk segmentation will only be generated if your emuDB contains
 audio files beyond the one minute mark.}
 
 \item{resume}{If a previous call to this function has failed (and you think you have fixed the issue
 that caused the error), you can set resume=TRUE to recover any progress made up to that point. This
-will only work if you have not run any other emuR functions (such as the query function or other
-webservice functions) in the meantime, as they are likely to delete your temporary data.}
+will only work if your R temporary directory has not been deleted or emptied in the meantime.}
 
 \item{verbose}{Display progress bars and other information}
 }

--- a/man/runBASwebservice_chunker.Rd
+++ b/man/runBASwebservice_chunker.Rd
@@ -4,14 +4,15 @@
 \alias{runBASwebservice_chunker}
 \title{Creates a chunk segmentation using the webservice Chunker.}
 \usage{
-runBASwebservice_chunker(handle, canoLabel, language, chunkLabel = "TRN",
-  rootLabel = NULL, orthoLabel = NULL, params = list(force = "rescue"),
+runBASwebservice_chunker(handle, canoAttributeDefinitionName, language,
+  chunkAttributeDefinitionName = "TRN", rootLevel = NULL,
+  orthoAttributeDefinitionName = NULL, params = list(force = "rescue"),
   perspective = "default", resume = FALSE, verbose = TRUE)
 }
 \arguments{
 \item{handle}{emuDB handle}
 
-\item{canoLabel}{name of the label (not level!) containing a canonical pronunciation of the words.}
+\item{canoAttributeDefinitionName}{name of the attribute (not level!) containing a canonical pronunciation of the words.}
 
 \item{language}{language(s) to be used. If you pass a single string (e.g. "deu-DE"), this language will be used for all bundles.
 Alternatively, you can select the language for every bundle individually. To do so, you must pass a data frame with the columns
@@ -19,12 +20,12 @@ session, bundle, language. This data frame must contain one row for every bundle
 Up-to-date lists of the languages accepted by all webservices can be found here:
 \url{https://clarin.phonetik.uni-muenchen.de/BASWebServices/services/help}}
 
-\item{chunkLabel}{label name for the chunk segmentation}
+\item{chunkAttributeDefinitionName}{attribute name for the chunk segmentation}
 
-\item{rootLabel}{if provided, the new level will be linked to the root level}
+\item{rootLevel}{if provided, the new level will be linked to the root level}
 
-\item{orthoLabel}{if provided, chunk labels will contain orthographic instead of SAMPA strings.
-Must be paired with the canonical pronunciation labels in canoLabel.}
+\item{orthoAttributeDefinitionName}{if provided, chunk attributes will contain orthographic instead of SAMPA strings.
+Must be paired with the canonical pronunciation attributes in canoAttributeDefinitionName.}
 
 \item{params}{named list of parameters to be passed on to the webservice. It is your own reponsibility to
 ensure that these parameters are compatible with the webservice API
@@ -37,8 +38,7 @@ If NULL, the new level is not added to any perspectives.}
 
 \item{resume}{If a previous call to this function has failed (and you think you have fixed the issue
 that caused the error), you can set resume=TRUE to recover any progress made up to that point. This
-will only work if you have not run any other emuR functions (such as the query function or other
-webservice functions) in the meantime, as they are likely to delete your temporary data.}
+will only work if your R temporary directory has not been deleted or emptied in the meantime.}
 
 \item{verbose}{Display progress bars and other information}
 }
@@ -46,7 +46,7 @@ webservice functions) in the meantime, as they are likely to delete your tempora
 When audio input files are longer than approximately 10 minutes, alignment-based segmentation
 tools such as MAUS will take a long time to run. In these cases, the Chunker pre-segments
 the input into more digestable "chunks". As input, it requires a word tier with canonical
-pronunciation labels (which can be derived by \link{runBASwebservice_g2pForPronunciation}).
+pronunciation attributes (which can be derived by \link{runBASwebservice_g2pForPronunciation}).
 The resulting chunk level can be passed as input to \link{runBASwebservice_maus}.
 \strong{This function requires an internet connection.}
 }

--- a/man/runBASwebservice_g2pForPronunciation.Rd
+++ b/man/runBASwebservice_g2pForPronunciation.Rd
@@ -2,16 +2,16 @@
 % Please edit documentation in R/emuR-bas_webservices.R
 \name{runBASwebservice_g2pForPronunciation}
 \alias{runBASwebservice_g2pForPronunciation}
-\title{Creates canonical pronunciation labels for a tier of tokenized orthographical words.}
+\title{Creates canonical pronunciation attributes for a tier of tokenized orthographical words.}
 \usage{
-runBASwebservice_g2pForPronunciation(handle, orthoLabel, language,
-  canoLabel = "KAN", params = list(embed = "maus"), resume = FALSE,
-  verbose = TRUE)
+runBASwebservice_g2pForPronunciation(handle, orthoAttributeDefinitionName,
+  language, canoAttributeDefinitionName = "KAN", params = list(embed =
+  "maus"), resume = FALSE, verbose = TRUE)
 }
 \arguments{
 \item{handle}{emuDB handle}
 
-\item{orthoLabel}{name of a label (not level!) containing orthographic words.}
+\item{orthoAttributeDefinitionName}{name of a attribute (not level!) containing orthographic words.}
 
 \item{language}{language(s) to be used. If you pass a single string (e.g. "deu-DE"), this language will be used for all bundles.
 Alternatively, you can select the language for every bundle individually. To do so, you must pass a data frame with the columns
@@ -19,7 +19,7 @@ session, bundle, language. This data frame must contain one row for every bundle
 Up-to-date lists of the languages accepted by all webservices can be found here:
 \url{https://clarin.phonetik.uni-muenchen.de/BASWebServices/services/help}}
 
-\item{canoLabel}{label name for canonical pronunciations of words}
+\item{canoAttributeDefinitionName}{attribute name for canonical pronunciations of words}
 
 \item{params}{named list of parameters to be passed on to the webservice. It is your own reponsibility to
 ensure that these parameters are compatible with the webservice API
@@ -29,13 +29,12 @@ and will be overridden.}
 
 \item{resume}{If a previous call to this function has failed (and you think you have fixed the issue
 that caused the error), you can set resume=TRUE to recover any progress made up to that point. This
-will only work if you have not run any other emuR functions (such as the query function or other
-webservice functions) in the meantime, as they are likely to delete your temporary data.}
+will only work if your R temporary directory has not been deleted or emptied in the meantime.}
 
 \item{verbose}{Display progress bars and other information}
 }
 \description{
-This function calls the G2P webservice to add canonical pronunciation labels in SAMPA (default)
+This function calls the G2P webservice to add canonical pronunciation attributes in SAMPA (default)
 or IPA to a tier of tokenized orthographical words. It is usually called after tokenization
 with \link{runBASwebservice_g2pForTokenization}. Its output can be used as input to
 \link{runBASwebservice_maus} or \link{runBASwebservice_chunker}.

--- a/man/runBASwebservice_g2pForTokenization.Rd
+++ b/man/runBASwebservice_g2pForTokenization.Rd
@@ -4,13 +4,15 @@
 \alias{runBASwebservice_g2pForTokenization}
 \title{Tokenizes an orthographic transcription.}
 \usage{
-runBASwebservice_g2pForTokenization(handle, transcriptionLabel, language,
-  orthoLabel = "ORT", params = list(), resume = FALSE, verbose = TRUE)
+runBASwebservice_g2pForTokenization(handle,
+  transcriptionAttributeDefinitionName, language,
+  orthoAttributeDefinitionName = "ORT", params = list(), resume = FALSE,
+  verbose = TRUE)
 }
 \arguments{
 \item{handle}{emuDB handle}
 
-\item{transcriptionLabel}{name of the label (not level!) containing an orthographic transcription.}
+\item{transcriptionAttributeDefinitionName}{name of the attribute (not level!) containing an orthographic transcription.}
 
 \item{language}{language(s) to be used. If you pass a single string (e.g. "deu-DE"), this language will be used for all bundles.
 Alternatively, you can select the language for every bundle individually. To do so, you must pass a data frame with the columns
@@ -18,7 +20,7 @@ session, bundle, language. This data frame must contain one row for every bundle
 Up-to-date lists of the languages accepted by all webservices can be found here:
 \url{https://clarin.phonetik.uni-muenchen.de/BASWebServices/services/help}}
 
-\item{orthoLabel}{label name for orthographic words}
+\item{orthoAttributeDefinitionName}{attribute name for orthographic words}
 
 \item{params}{named list of parameters to be passed on to the webservice. It is your own reponsibility to
 ensure that these parameters are compatible with the webservice API
@@ -28,8 +30,7 @@ and will be overridden.}
 
 \item{resume}{If a previous call to this function has failed (and you think you have fixed the issue
 that caused the error), you can set resume=TRUE to recover any progress made up to that point. This
-will only work if you have not run any other emuR functions (such as the query function or other
-webservice functions) in the meantime, as they are likely to delete your temporary data.}
+will only work if your R temporary directory has not been deleted or emptied in the meantime.}
 
 \item{verbose}{Display progress bars and other information}
 }

--- a/man/runBASwebservice_maus.Rd
+++ b/man/runBASwebservice_maus.Rd
@@ -4,15 +4,16 @@
 \alias{runBASwebservice_maus}
 \title{Runs MAUS webservice to create a phonetic segmentation}
 \usage{
-runBASwebservice_maus(handle, canoLabel, language, mausLabel = "MAU",
-  chunkLabel = NULL, turnChunkLevelIntoItemLevel = TRUE, params = NULL,
+runBASwebservice_maus(handle, canoAttributeDefinitionName, language,
+  mausAttributeDefinitionName = "MAU", chunkLevel = NULL,
+  turnChunkLevelIntoItemLevel = TRUE, params = NULL,
   perspective = "default", resume = FALSE, verbose = TRUE)
 }
 \arguments{
 \item{handle}{emuDB handle}
 
-\item{canoLabel}{name of the label (not level!) containing the SAMPA word pronunciations.
-If this label resides on a segment level, the segment time information is used as a presegmentation.
+\item{canoAttributeDefinitionName}{name of the attribute (not level!) containing the SAMPA word pronunciations.
+If this attribute resides on a segment level, the segment time information is used as a presegmentation.
 If it is an item level, no assumption is made about the temporal position of segments.}
 
 \item{language}{language(s) to be used. If you pass a single string (e.g. "deu-DE"), this language will be used for all bundles.
@@ -21,10 +22,10 @@ session, bundle, language. This data frame must contain one row for every bundle
 Up-to-date lists of the languages accepted by all webservices can be found here:
 \url{https://clarin.phonetik.uni-muenchen.de/BASWebServices/services/help}}
 
-\item{mausLabel}{label name for the MAUS segmentation}
+\item{mausAttributeDefinitionName}{attribute name for the MAUS segmentation}
 
-\item{chunkLabel}{if you have a chunk segmentation level, you can provide one of its labels to improve the speed and accuracy
-of MAUS. The chunk segmentation level must be a segment level, and it must link to the level of orthoLabel.}
+\item{chunkLevel}{if you have a chunk segmentation level, you can provide it to improve the speed and accuracy
+of MAUS. The chunk segmentation level must be a segment level, and it must link to the level of canoAttributeDefinitionName.}
 
 \item{turnChunkLevelIntoItemLevel}{if TRUE, and if a chunk level is provided, the chunk level is converted into an ITEM level after segmentation}
 
@@ -39,8 +40,7 @@ If NULL, the new level is not added to any perspectives.}
 
 \item{resume}{If a previous call to this function has failed (and you think you have fixed the issue
 that caused the error), you can set resume=TRUE to recover any progress made up to that point. This
-will only work if you have not run any other emuR functions (such as the query function or other
-webservice functions) in the meantime, as they are likely to delete your temporary data.}
+will only work if your R temporary directory has not been deleted or emptied in the meantime.}
 
 \item{verbose}{Display progress bars and other information}
 }

--- a/man/runBASwebservice_minni.Rd
+++ b/man/runBASwebservice_minni.Rd
@@ -4,9 +4,10 @@
 \alias{runBASwebservice_minni}
 \title{Creates a rough phonetic segmentation by running the phoneme decoder webservice MINNI.}
 \usage{
-runBASwebservice_minni(handle, language, minniLabel = "MINNI",
-  rootLabel = NULL, params = list(), perspective = "default",
-  resume = FALSE, verbose = TRUE)
+runBASwebservice_minni(handle, language,
+  minniAttributeDefinitionName = "MINNI", rootLevel = NULL,
+  params = list(), perspective = "default", resume = FALSE,
+  verbose = TRUE)
 }
 \arguments{
 \item{handle}{emuDB handle}
@@ -17,9 +18,9 @@ session, bundle, language. This data frame must contain one row for every bundle
 Up-to-date lists of the languages accepted by all webservices can be found here:
 \url{https://clarin.phonetik.uni-muenchen.de/BASWebServices/services/help}}
 
-\item{minniLabel}{label name for the MINNI segmentation}
+\item{minniAttributeDefinitionName}{attribute name for the MINNI segmentation}
 
-\item{rootLabel}{if provided, the new level will be linked to the root level}
+\item{rootLevel}{if provided, the new level will be linked to the root level}
 
 \item{params}{named list of parameters to be passed on to the webservice. It is your own reponsibility to
 ensure that these parameters are compatible with the webservice API
@@ -32,16 +33,15 @@ If NULL, the new level is not added to any perspectives.}
 
 \item{resume}{If a previous call to this function has failed (and you think you have fixed the issue
 that caused the error), you can set resume=TRUE to recover any progress made up to that point. This
-will only work if you have not run any other emuR functions (such as the query function or other
-webservice functions) in the meantime, as they are likely to delete your temporary data.}
+will only work if your R temporary directory has not been deleted or emptied in the meantime.}
 
 \item{verbose}{Display progress bars and other information}
 }
 \description{
 The MINNI phoneme decoder performs phoneme-based decoding on the signal without input from
 the transcription. Therefore, labelling quality is usually worse than that obtained from
-MAUS (\link{runBASwebservice_maus}). Contrary to MAUS however, there is no need for a pre-
-existing transcription.
+MAUS (\link{runBASwebservice_maus}). Contrary to MAUS however, there is no need for a
+pre-existing transcription.
 }
 \details{
 All necessary level, link and attribute definitions are created in the process.

--- a/man/runBASwebservice_pho2sylCanonical.Rd
+++ b/man/runBASwebservice_pho2sylCanonical.Rd
@@ -2,15 +2,16 @@
 % Please edit documentation in R/emuR-bas_webservices.R
 \name{runBASwebservice_pho2sylCanonical}
 \alias{runBASwebservice_pho2sylCanonical}
-\title{Adds syllabified word labels to a word level that already contains a canonical pronunciation label.}
+\title{Adds syllabified word labels to a word level that already contains canonical pronunciations.}
 \usage{
-runBASwebservice_pho2sylCanonical(handle, canoLabel, language,
-  canoSylLabel = "KAS", params = list(), resume = FALSE, verbose = TRUE)
+runBASwebservice_pho2sylCanonical(handle, canoAttributeDefinitionName, language,
+  canoSylAttributeDefinitionName = "KAS", params = list(), resume = FALSE,
+  verbose = TRUE)
 }
 \arguments{
 \item{handle}{emuDB handle}
 
-\item{canoLabel}{name of the label (not level!) containing a canonical pronunciation of the words.}
+\item{canoAttributeDefinitionName}{name of the attribute (not level!) containing a canonical pronunciation of the words.}
 
 \item{language}{language(s) to be used. If you pass a single string (e.g. "deu-DE"), this language will be used for all bundles.
 Alternatively, you can select the language for every bundle individually. To do so, you must pass a data frame with the columns
@@ -18,7 +19,7 @@ session, bundle, language. This data frame must contain one row for every bundle
 Up-to-date lists of the languages accepted by all webservices can be found here:
 \url{https://clarin.phonetik.uni-muenchen.de/BASWebServices/services/help}}
 
-\item{canoSylLabel}{label name for syllabified canonical pronunciations of words}
+\item{canoSylAttributeDefinitionName}{attribute name for syllabified canonical pronunciations of words}
 
 \item{params}{named list of parameters to be passed on to the webservice. It is your own reponsibility to
 ensure that these parameters are compatible with the webservice API
@@ -28,14 +29,13 @@ and will be overridden.}
 
 \item{resume}{If a previous call to this function has failed (and you think you have fixed the issue
 that caused the error), you can set resume=TRUE to recover any progress made up to that point. This
-will only work if you have not run any other emuR functions (such as the query function or other
-webservice functions) in the meantime, as they are likely to delete your temporary data.}
+will only work if your R temporary directory has not been deleted or emptied in the meantime.}
 
 \item{verbose}{Display progress bars and other information}
 }
 \description{
-This function calls the webservice Pho2Syl to add a syllabified canonical pronunciation label
-to a word level that already contains an unsyllabified canonical pronunciation label (as can be
+This function calls the webservice Pho2Syl to add syllabified canonical pronunciation labels
+to a word level that already contains unsyllabified canonical pronunciation labels (as can be
 derived using \link{runBASwebservice_g2pForPronunciation}). \strong{This function requires an internet
 connection.}
 }

--- a/man/runBASwebservice_pho2sylSegmental.Rd
+++ b/man/runBASwebservice_pho2sylSegmental.Rd
@@ -4,14 +4,15 @@
 \alias{runBASwebservice_pho2sylSegmental}
 \title{Creates a syllable segmentation on the basis of a phonetic segmentation.}
 \usage{
-runBASwebservice_pho2sylSegmental(handle, segmentLabel, language,
-  superLabel = NULL, sylLabel = "MAS", params = list(wsync = "yes"),
-  perspective = "default", resume = FALSE, verbose = TRUE)
+runBASwebservice_pho2sylSegmental(handle, segmentAttributeDefinitionName,
+  language, superLevel = NULL, sylAttributeDefinitionName = "MAS",
+  params = list(wsync = "yes"), perspective = "default", resume = FALSE,
+  verbose = TRUE)
 }
 \arguments{
 \item{handle}{emuDB handle}
 
-\item{segmentLabel}{name of the label (not level!) containing a phonetic segmentation.}
+\item{segmentAttributeDefinitionName}{name of the attribute (not level!) containing a phonetic segmentation.}
 
 \item{language}{language(s) to be used. If you pass a single string (e.g. "deu-DE"), this language will be used for all bundles.
 Alternatively, you can select the language for every bundle individually. To do so, you must pass a data frame with the columns
@@ -19,10 +20,10 @@ session, bundle, language. This data frame must contain one row for every bundle
 Up-to-date lists of the languages accepted by all webservices can be found here:
 \url{https://clarin.phonetik.uni-muenchen.de/BASWebServices/services/help}}
 
-\item{superLabel}{name of a label on the segments' parent level (typically words).
+\item{superLevel}{name of the segments' parent level (typically the word level).
 If set to NULL, the syllable level cannot be linked up.}
 
-\item{sylLabel}{label name for syllable segmentation}
+\item{sylAttributeDefinitionName}{attribute name for syllable segmentation}
 
 \item{params}{named list of parameters to be passed on to the webservice. It is your own reponsibility to
 ensure that these parameters are compatible with the webservice API
@@ -35,16 +36,15 @@ If NULL, the new level is not added to any perspectives.}
 
 \item{resume}{If a previous call to this function has failed (and you think you have fixed the issue
 that caused the error), you can set resume=TRUE to recover any progress made up to that point. This
-will only work if you have not run any other emuR functions (such as the query function or other
-webservice functions) in the meantime, as they are likely to delete your temporary data.}
+will only work if your R temporary directory has not been deleted or emptied in the meantime.}
 
 \item{verbose}{Display progress bars and other information}
 }
 \description{
 This function calls the BAS webservice Pho2Syl to create a syllable segmentation on the basis
 of a phonetic segmentation (created by, for example, \link{runBASwebservice_maus}).
-You can provide the name of your word segmentation, or of any other hierarchically
-dominant segmentation, via the superLabel parameter. This way, the new syllable
+You can provide the level of your word segmentation, or of any other hierarchically
+dominant segmentation, via the superLevel parameter. This way, the new syllable
 items can be linked up into the pre-existing hierarchy. If you do not provide
 this input, the syllables will only be linked down to the segments.
 }

--- a/tests/testthat/test_emuR-bas_webservices.R
+++ b/tests/testthat/test_emuR-bas_webservices.R
@@ -40,19 +40,19 @@ test_that(
     runBASwebservice_chunker(handle,
                              "KAN",
                              "eng-GB",
-                             rootLabel = "transcription",
+                             rootLevel = "bundle",
                              verbose = F)
     runBASwebservice_maus(handle,
                           "KAN",
                           "eng-GB",
-                          chunkLabel = "TRN",
+                          chunkLevel = "TRN",
                           verbose = F)
-    runBASwebservice_minni(handle, "eng-GB", rootLabel = "transcription", verbose = F)
+    runBASwebservice_minni(handle, "eng-GB", rootLevel = "bundle", verbose = F)
     runBASwebservice_pho2sylCanonical(handle, "KAN", "eng-GB", verbose = F)
     runBASwebservice_pho2sylSegmental(handle,
                                       "MAU",
                                       "eng-GB",
-                                      superLabel = "ORT",
+                                      superLevel = "ORT",
                                       verbose = F)
   }
 )


### PR DESCRIPTION
- Renamed parameters in BAS webservice functions (*Label -> *AttributeDefinitionName)
- Bugfix to keep race conditions from happening when two Rscripts call webservices simultaneously
- BAS webservice functions now query the version of the respective webservice + put it in the attributeDefinition description