### PR TITLE
Fix Windows re-encoding issue for BAS service calls

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: emuR
-Version: 0.2.3
+Version: 0.2.3.1234
 Title: Main Package of the EMU Speech Database Management System
 Authors@R: c(
     person("Raphael", "Winkelmann", , "raphael@phonetik.uni-muenchen.de", c("aut", "cre")),

--- a/R/emuR-bas_webservicesDBI.R
+++ b/R/emuR-bas_webservicesDBI.R
@@ -129,7 +129,7 @@ bas_run_maus_dbi <- function(handle,
         
         kancon <- file(kanfile)
         open(kancon, "w")
-        write(paste0("SAM: ", samplerate, "\nLBD:"), kancon)
+        writeLines(paste0("SAM: ", samplerate, "\nLBD:"), kancon, useBytes = T)
         
         bas_id = 0
         item_id_to_bas_id = new.env(hash = TRUE)
@@ -141,7 +141,7 @@ bas_run_maus_dbi <- function(handle,
           cano_item_id = cano_items_bundle[label_idx, "start_item_id"]
           
           kanline = paste0("KAN: ", bas_id, " ", cano_label)
-          write(kanline, kancon)
+          writeLines(kanline, kancon, useBytes = T)
           
           item_id_to_bas_id[[toString(cano_item_id)]] = bas_id
           bas_id_to_item_id[[toString(bas_id)]] = cano_item_id
@@ -199,7 +199,7 @@ bas_run_maus_dbi <- function(handle,
                 "_"
               )
               
-              write(trnline, kancon)
+              writeLines(trnline, kancon, useBytes = T)
             }
           }
         }
@@ -583,7 +583,7 @@ bas_run_g2p_for_tokenization_dbi <- function(handle,
                                 ".g2p.par"
                               ))
           
-          write(transcription_label, file = textfile)
+          writeLines(transcription_label, con = textfile, useBytes = T)
           
           curlParams = list(
             lng = language,
@@ -751,7 +751,7 @@ bas_run_g2p_for_pronunciation_dbi <- function(handle,
         
         orthoCon <- file(orthofile)
         open(orthoCon, "w")
-        write(paste0("SAM: ", samplerate, "\nLBD:"), orthoCon)
+        writeLines(paste0("SAM: ", samplerate, "\nLBD:"), orthoCon, useBytes = T)
         
         bas_id = 0
         
@@ -762,7 +762,7 @@ bas_run_g2p_for_pronunciation_dbi <- function(handle,
           ortho_label = stringr::str_trim(ortho_items_bundle[label_idx, "labels"])
           ortho_item_id = ortho_items_bundle[label_idx, "start_item_id"]
           
-          write(paste("ORT:", bas_id, ortho_label), orthoCon)
+          writeLines(paste("ORT:", bas_id, ortho_label), orthoCon, useBytes = T)
           bas_id_to_item_id[[toString(bas_id)]] = ortho_item_id
           bas_id = bas_id + 1
         }
@@ -934,7 +934,7 @@ bas_run_chunker_dbi <- function(handle,
         
         kancon <- file(kanfile)
         open(kancon, "w")
-        write(paste0("SAM: ", samplerate, "\nLBD:"), kancon)
+        writeLines(paste0("SAM: ", samplerate, "\nLBD:"), kancon, useBytes = T)
         
         bas_id = 0
         item_id_to_bas_id = new.env(hash = TRUE)
@@ -956,13 +956,13 @@ bas_run_chunker_dbi <- function(handle,
             
             if (length(ortho_labels) > 0)
             {
-              write(paste0("ORT: ", bas_id, " ", ortho_labels[1, "labels"]),
-                    kancon)
+              writeLines(paste0("ORT: ", bas_id, " ", ortho_labels[1, "labels"]),
+                    kancon, useBytes = T)
             }
           }
           
-          write(paste0("KAN: ", bas_id, " ", cano_label),
-                kancon)
+          writeLines(paste0("KAN: ", bas_id, " ", cano_label),
+                kancon, useBytes = T)
           item_id_to_bas_id[[toString(cano_item_id)]] = bas_id
           bas_id_to_item_id[[toString(bas_id)]] = cano_item_id
           bas_id = bas_id + 1
@@ -1167,7 +1167,7 @@ bas_run_pho2syl_canonical_dbi <- function(handle,
         
         kancon <- file(kanfile)
         open(kancon, "w")
-        write(paste0("SAM: ", samplerate, "\nLBD:"), kancon)
+        writeLines(paste0("SAM: ", samplerate, "\nLBD:"), kancon, useBytes = T)
         
         bas_id = 0
         bas_id_to_item_id = new.env(hash = TRUE)
@@ -1178,7 +1178,7 @@ bas_run_pho2syl_canonical_dbi <- function(handle,
           cano_item_id = cano_items_bundle[label_idx, "start_item_id"]
           
           kanline = paste0("KAN: ", bas_id, " ", cano_label)
-          write(kanline, kancon)
+          writeLines(kanline, kancon, useBytes = T)
           
           bas_id_to_item_id[[toString(bas_id)]] = cano_item_id
           bas_id = bas_id + 1
@@ -1467,7 +1467,7 @@ bas_run_pho2syl_segmental_dbi_anchored <- function(handle,
         
         maucon <- file(maufile)
         open(maucon, "w")
-        write(paste0("SAM: ", samplerate, "\nLBD:"), maucon)
+        writeLines(paste0("SAM: ", samplerate, "\nLBD:"), maucon, useBytes = T)
         
         bas_id = 0
         bas_id_to_word_item_id = new.env(hash = TRUE)
@@ -1495,7 +1495,7 @@ bas_run_pho2syl_segmental_dbi_anchored <- function(handle,
             if (stringr::str_length(mau_label) > 0 &&
                 mau_start >= word_start)
             {
-              write(
+              writeLines(
                 paste0(
                   "MAU: ",
                   mau_start,
@@ -1506,7 +1506,8 @@ bas_run_pho2syl_segmental_dbi_anchored <- function(handle,
                   " ",
                   mau_label
                 ),
-                maucon
+                maucon,
+                useBytes = T
               )
               
               written_mau = TRUE
@@ -1706,7 +1707,7 @@ bas_run_pho2syl_segmental_dbi_unanchored <- function(handle,
         
         maucon <- file(maufile)
         open(maucon, "w")
-        write(paste0("SAM: ", samplerate, "\nLBD:"), maucon)
+        writeLines(paste0("SAM: ", samplerate, "\nLBD:"), maucon, useBytes = T)
         
         
         for (mau_idx in 1:nrow(maus_items_bundle))
@@ -1718,7 +1719,7 @@ bas_run_pho2syl_segmental_dbi_unanchored <- function(handle,
           
           if (stringr::str_length(mau_label) > 0)
           {
-            write(paste0(
+            writeLines(paste0(
               "MAU: ",
               mau_start,
               " ",
@@ -1726,7 +1727,8 @@ bas_run_pho2syl_segmental_dbi_unanchored <- function(handle,
               " 0 ",
               mau_label
             ),
-            maucon)
+            maucon,
+            useBytes = T)
             
           }
         }
@@ -1938,7 +1940,7 @@ bas_download <- function(result,
     cacheOK = TRUE
   )
   
-  lines = try(readLines(target))
+  lines = try(readLines(target, encoding = "UTF-8"))
   
   if (class(lines) == "try-error")
   {


### PR DESCRIPTION
We encountered the same bug that was fixed in 5d29c6e (reencoding under windows) while running g2p from emuR. With this fix, the process worked correctly on our data.

In this case, it was not the annot.json's that were falsely re-encoded, but the transcription text files written by the g2p function and the BPF files returned by the web service.

@NPoe it would be good if you had a look at this.

@raphywink there is one instance of read() -> readLines() in this commit. readLines() does not have the useBytes parameter, so instead I hardcoded ```encoding="UTF-8"```. Did the trick for us, but I don't know if this is a good idea for the master branch.