### PR TITLE
Bugfix in BPF export

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: emuR
-Version: 0.2.3.1234
+Version: 0.2.3.9001
 Title: Main Package of the EMU Speech Database Management System
 Authors@R: c(
     person("Raphael", "Winkelmann", , "raphael@phonetik.uni-muenchen.de", c("aut", "cre")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+# emuR 0.2.3.9001
+
+## bugfixes
+
+* fixed a bug in the BPF export function, which meant that WAVE files were only copied into one session
+
+
 # emuR 0.2.3
 
 ## new features / performance tweaks / improvements

--- a/R/emuR-export_BPFCollection.R
+++ b/R/emuR-export_BPFCollection.R
@@ -322,32 +322,32 @@ build_skeleton <- function(handle, targetDir, copyAudio, verbose)
       progress = progress + 1
       utils::setTxtProgressBar(pb, progress)
     }
-  }
     
-  if(copyAudio)
-  {
-    for(bundle in list_bundles(handle, session = session)$name)
+    if(copyAudio)
     {
-      queryTxt = paste0("SELECT annotates FROM bundle", 
+      for(bundle in list_bundles(handle, session = session)$name)
+      {
+        queryTxt = paste0("SELECT annotates FROM bundle", 
                         basic_cond(handle, session, bundle, bundlename="name"))
       
-      annotates = DBI::dbGetQuery(handle$connection, queryTxt)[1,1]
+        annotates = DBI::dbGetQuery(handle$connection, queryTxt)[1,1]
         
-      wav_target = file.path(targetDir, 
+        wav_target = file.path(targetDir, 
                              handle$dbName,
                              session,
                              annotates)
 
-      wav_source = file.path(handle$basePath,
+        wav_source = file.path(handle$basePath,
                              paste0(session, session.suffix),
                              paste0(bundle, bundle.dir.suffix),
                              annotates)
       
-      file.copy(wav_source, wav_target)
-      if(verbose)
-      {
-        progress = progress + 1
-        utils::setTxtProgressBar(pb, progress)
+        file.copy(wav_source, wav_target)
+        if(verbose)
+        {
+          progress = progress + 1
+          utils::setTxtProgressBar(pb, progress)
+        }
       }
     }
   }


### PR DESCRIPTION
BPF export had a bug where, if copyAudio=TRUE, only the audio files of the last session were copied.