### PR TITLE
Patience parameter for webservice calls

### DIFF
--- a/R/emuR-bas_webservices.R
+++ b/R/emuR-bas_webservices.R
@@ -40,6 +40,8 @@
 ##' @param sylAttributeDefinitionName attribute name for syllable segmentation
 ##' @param canoSylAttributeDefinitionName attribute name for syllabified canonical pronunciations of words
 ##'
+##' @param patience If a web service call fails, it is repeated a further n times, with n being the value of patience.
+##' Must be set to a value between 0 and 3.
 ##' @param verbose Display progress bars and other information
 ##' @param resume If a previous call to this function has failed (and you think you have fixed the issue
 ##' that caused the error), you can set resume=TRUE to recover any progress made up to that point. This
@@ -57,6 +59,7 @@ runBASwebservice_all <- function(handle,
                                  canoSylAttributeDefinitionName = "KAS",
                                  chunkAttributeDefinitionName = "TRN",
                                  
+                                 patience = 0,
                                  resume = FALSE,
                                  verbose = TRUE)
 {
@@ -101,7 +104,8 @@ runBASwebservice_all <- function(handle,
     verbose = verbose,
     resume = resume,
     params = list(),
-    func = func
+    func = func,
+    patience = patience
   )
   
   bas_run_g2p_for_pronunciation_dbi(
@@ -112,7 +116,8 @@ runBASwebservice_all <- function(handle,
     verbose = verbose,
     resume = resume,
     params = list(embed = "maus"),
-    func = func
+    func = func,
+    patience = patience
   )
   
   
@@ -131,7 +136,8 @@ runBASwebservice_all <- function(handle,
       language = language,
       oldBasePath = oldBasePath,
       perspective = "default",
-      func = func
+      func = func,
+      patience = patience
     )
   }
   
@@ -147,7 +153,8 @@ runBASwebservice_all <- function(handle,
     oldBasePath = oldBasePath,
     perspective = "default",
     turnChunkLevelIntoItemLevel = T,
-    func = func
+    func = func,
+    patience = patience
   )
   
   bas_run_minni_dbi(
@@ -160,7 +167,8 @@ runBASwebservice_all <- function(handle,
     params = list(),
     oldBasePath = oldBasePath,
     perspective = "default",
-    func = func
+    func = func,
+    patience = patience
   )
   
   bas_run_pho2syl_canonical_dbi(
@@ -171,7 +179,8 @@ runBASwebservice_all <- function(handle,
     verbose = verbose,
     params = list(),
     resume = resume,
-    func = func
+    func = func,
+    patience = patience
   )
   
   orthoLevel = orthoAttributeDefinitionName
@@ -185,7 +194,8 @@ runBASwebservice_all <- function(handle,
     resume = resume,
     params = list(wsync = "yes"),
     verbose = verbose,
-    func = func
+    func = func,
+    patience = patience
   )
   
   
@@ -257,6 +267,7 @@ runBASwebservice_maus <- function(handle,
                                   params = NULL,
                                   
                                   perspective = "default",
+                                  patience = 0,
                                   resume = FALSE,
                                   verbose = TRUE)
 {
@@ -276,7 +287,8 @@ runBASwebservice_maus <- function(handle,
     oldBasePath = oldBasePath,
     perspective = perspective,
     turnChunkLevelIntoItemLevel = turnChunkLevelIntoItemLevel,
-    func = func
+    func = func,
+    patience = patience
   )
   
   handle = bas_clear(handle, oldBasePath, func)
@@ -313,6 +325,7 @@ runBASwebservice_g2pForTokenization <- function(handle,
                                                 
                                                 params = list(),
                                                 
+                                                patience = 0,
                                                 resume = FALSE,
                                                 verbose = TRUE)
 {
@@ -328,7 +341,8 @@ runBASwebservice_g2pForTokenization <- function(handle,
     verbose = verbose,
     resume = resume,
     params = params,
-    func = func
+    func = func,
+    patience = patience
   )
   
   handle = bas_clear(handle, oldBasePath, func)
@@ -365,6 +379,7 @@ runBASwebservice_g2pForPronunciation <- function(handle,
                                                  
                                                  params = list(embed = "maus"),
                                                  
+                                                 patience = 0,
                                                  resume = FALSE,
                                                  verbose = TRUE)
 {
@@ -380,7 +395,8 @@ runBASwebservice_g2pForPronunciation <- function(handle,
     verbose = verbose,
     resume = resume,
     params = params,
-    func = func
+    func = func,
+    patience = patience
   )
   
   handle = bas_clear(handle, oldBasePath, func)
@@ -434,6 +450,7 @@ runBASwebservice_chunker <- function(handle,
                                      params = list(force = "rescue"),
                                      
                                      perspective = "default",
+                                     patience = 0,
                                      resume = FALSE,
                                      verbose = TRUE)
 {
@@ -453,7 +470,8 @@ runBASwebservice_chunker <- function(handle,
     perspective = perspective,
     resume = resume,
     rootLevel = rootLevel,
-    func = func
+    func = func,
+    patience = patience
   )
   
   handle = bas_clear(handle, oldBasePath, func)
@@ -495,6 +513,7 @@ runBASwebservice_minni <- function(handle,
                                    params = list(),
                                    
                                    perspective = "default",
+                                   patience = 0,
                                    resume = FALSE,
                                    verbose = TRUE)
 {
@@ -512,7 +531,8 @@ runBASwebservice_minni <- function(handle,
     params = params,
     oldBasePath = oldBasePath,
     perspective = perspective,
-    func = func
+    func = func,
+    patience = patience
   )
   
   handle = bas_clear(handle, oldBasePath, func)
@@ -546,6 +566,7 @@ runBASwebservice_pho2sylCanonical <- function(handle,
                                               
                                               params = list(),
                                               
+                                              patience = 0,
                                               resume = FALSE,
                                               verbose = TRUE)
 {
@@ -561,7 +582,8 @@ runBASwebservice_pho2sylCanonical <- function(handle,
     canoSylAttributeDefinitionName = canoSylAttributeDefinitionName,
     resume = resume,
     params = params,
-    func = func
+    func = func,
+    patience = patience
   )
   
   
@@ -604,6 +626,7 @@ runBASwebservice_pho2sylSegmental <- function(handle,
                                               params = list(wsync = "yes"),
                                               
                                               perspective = "default",
+                                              patience = 0,
                                               resume = FALSE,
                                               verbose = TRUE)
 {
@@ -620,7 +643,8 @@ runBASwebservice_pho2sylSegmental <- function(handle,
     superLevel = superLevel,
     resume = resume,
     params = params,
-    func = func
+    func = func,
+    patience = patience
   )
   
   

--- a/R/emuR-bas_webservices.R
+++ b/R/emuR-bas_webservices.R
@@ -13,7 +13,7 @@
 ##' \itemize{
 ##' \item{Chunker: force=rescue}
 ##' \item{G2P: embed=maus}
-##' \item{Pho2Syl: wsync=no}
+##' \item{Pho2Syl: wsync=yes}
 ##' \item{MAUS: USETRN=[true if Chunker was called or transcription is a segment tier, false otherwise]}
 ##' }
 ##' If you wish to change parameters, you must use the individual runBASwebservices functions. This will also allow

--- a/R/emuR-bas_webservicesDBI.R
+++ b/R/emuR-bas_webservicesDBI.R
@@ -2454,6 +2454,12 @@ bas_paste_description <-
     )
     
     version = stringr::str_trim(version)
+    
+    if(nchar(version) == 0)
+    {
+      warning("Could not retrieve version number for service", service)
+    }
+    
     description = paste0(description, " automatically derived ")
     if (!is.null(source))
     {
@@ -2471,5 +2477,6 @@ bas_paste_description <-
         )), collapse = " "),
         ")"
       )
+    
     return(description)
   }

--- a/man/runBASwebservice_all.Rd
+++ b/man/runBASwebservice_all.Rd
@@ -64,7 +64,7 @@ Note that this function will run all BAS webservices with default parameters, wi
 \itemize{
 \item{Chunker: force=rescue}
 \item{G2P: embed=maus}
-\item{Pho2Syl: wsync=no}
+\item{Pho2Syl: wsync=yes}
 \item{MAUS: USETRN=[true if Chunker was called or transcription is a segment tier, false otherwise]}
 }
 If you wish to change parameters, you must use the individual runBASwebservices functions. This will also allow

--- a/man/runBASwebservice_all.Rd
+++ b/man/runBASwebservice_all.Rd
@@ -10,7 +10,8 @@ runBASwebservice_all(handle, transcriptionAttributeDefinitionName, language,
   minniAttributeDefinitionName = "MINNI",
   sylAttributeDefinitionName = "MAS",
   canoSylAttributeDefinitionName = "KAS",
-  chunkAttributeDefinitionName = "TRN", resume = FALSE, verbose = TRUE)
+  chunkAttributeDefinitionName = "TRN", patience = 0, resume = FALSE,
+  verbose = TRUE)
 }
 \arguments{
 \item{handle}{emuDB handle}
@@ -38,6 +39,9 @@ Up-to-date lists of the languages accepted by all webservices can be found here:
 \item{chunkAttributeDefinitionName}{attribute name for the chunk segmentation.
 Please note that the chunk segmentation will only be generated if your emuDB contains
 audio files beyond the one minute mark.}
+
+\item{patience}{If a web service call fails, it is repeated a further n times, with n being the value of patience.
+Must be set to a value between 0 and 3.}
 
 \item{resume}{If a previous call to this function has failed (and you think you have fixed the issue
 that caused the error), you can set resume=TRUE to recover any progress made up to that point. This

--- a/man/runBASwebservice_chunker.Rd
+++ b/man/runBASwebservice_chunker.Rd
@@ -7,7 +7,7 @@
 runBASwebservice_chunker(handle, canoAttributeDefinitionName, language,
   chunkAttributeDefinitionName = "TRN", rootLevel = NULL,
   orthoAttributeDefinitionName = NULL, params = list(force = "rescue"),
-  perspective = "default", resume = FALSE, verbose = TRUE)
+  perspective = "default", patience = 0, resume = FALSE, verbose = TRUE)
 }
 \arguments{
 \item{handle}{emuDB handle}
@@ -35,6 +35,9 @@ and will be overridden.}
 
 \item{perspective}{the webApp perspective that the new level will be added to.
 If NULL, the new level is not added to any perspectives.}
+
+\item{patience}{If a web service call fails, it is repeated a further n times, with n being the value of patience.
+Must be set to a value between 0 and 3.}
 
 \item{resume}{If a previous call to this function has failed (and you think you have fixed the issue
 that caused the error), you can set resume=TRUE to recover any progress made up to that point. This

--- a/man/runBASwebservice_g2pForPronunciation.Rd
+++ b/man/runBASwebservice_g2pForPronunciation.Rd
@@ -6,7 +6,7 @@
 \usage{
 runBASwebservice_g2pForPronunciation(handle, orthoAttributeDefinitionName,
   language, canoAttributeDefinitionName = "KAN", params = list(embed =
-  "maus"), resume = FALSE, verbose = TRUE)
+  "maus"), patience = 0, resume = FALSE, verbose = TRUE)
 }
 \arguments{
 \item{handle}{emuDB handle}
@@ -26,6 +26,9 @@ ensure that these parameters are compatible with the webservice API
 (see \url{https://clarin.phonetik.uni-muenchen.de/BASWebServices/services/help}).
 Some options accepted by the API (e.g. output format) cannot be set when calling a webservice from within emuR,
 and will be overridden.}
+
+\item{patience}{If a web service call fails, it is repeated a further n times, with n being the value of patience.
+Must be set to a value between 0 and 3.}
 
 \item{resume}{If a previous call to this function has failed (and you think you have fixed the issue
 that caused the error), you can set resume=TRUE to recover any progress made up to that point. This

--- a/man/runBASwebservice_g2pForTokenization.Rd
+++ b/man/runBASwebservice_g2pForTokenization.Rd
@@ -6,8 +6,8 @@
 \usage{
 runBASwebservice_g2pForTokenization(handle,
   transcriptionAttributeDefinitionName, language,
-  orthoAttributeDefinitionName = "ORT", params = list(), resume = FALSE,
-  verbose = TRUE)
+  orthoAttributeDefinitionName = "ORT", params = list(), patience = 0,
+  resume = FALSE, verbose = TRUE)
 }
 \arguments{
 \item{handle}{emuDB handle}
@@ -27,6 +27,9 @@ ensure that these parameters are compatible with the webservice API
 (see \url{https://clarin.phonetik.uni-muenchen.de/BASWebServices/services/help}).
 Some options accepted by the API (e.g. output format) cannot be set when calling a webservice from within emuR,
 and will be overridden.}
+
+\item{patience}{If a web service call fails, it is repeated a further n times, with n being the value of patience.
+Must be set to a value between 0 and 3.}
 
 \item{resume}{If a previous call to this function has failed (and you think you have fixed the issue
 that caused the error), you can set resume=TRUE to recover any progress made up to that point. This

--- a/man/runBASwebservice_maus.Rd
+++ b/man/runBASwebservice_maus.Rd
@@ -7,7 +7,7 @@
 runBASwebservice_maus(handle, canoAttributeDefinitionName, language,
   mausAttributeDefinitionName = "MAU", chunkLevel = NULL,
   turnChunkLevelIntoItemLevel = TRUE, params = NULL,
-  perspective = "default", resume = FALSE, verbose = TRUE)
+  perspective = "default", patience = 0, resume = FALSE, verbose = TRUE)
 }
 \arguments{
 \item{handle}{emuDB handle}
@@ -37,6 +37,9 @@ and will be overridden.}
 
 \item{perspective}{the webApp perspective that the new level will be added to.
 If NULL, the new level is not added to any perspectives.}
+
+\item{patience}{If a web service call fails, it is repeated a further n times, with n being the value of patience.
+Must be set to a value between 0 and 3.}
 
 \item{resume}{If a previous call to this function has failed (and you think you have fixed the issue
 that caused the error), you can set resume=TRUE to recover any progress made up to that point. This

--- a/man/runBASwebservice_minni.Rd
+++ b/man/runBASwebservice_minni.Rd
@@ -6,8 +6,8 @@
 \usage{
 runBASwebservice_minni(handle, language,
   minniAttributeDefinitionName = "MINNI", rootLevel = NULL,
-  params = list(), perspective = "default", resume = FALSE,
-  verbose = TRUE)
+  params = list(), perspective = "default", patience = 0,
+  resume = FALSE, verbose = TRUE)
 }
 \arguments{
 \item{handle}{emuDB handle}
@@ -30,6 +30,9 @@ and will be overridden.}
 
 \item{perspective}{the webApp perspective that the new level will be added to.
 If NULL, the new level is not added to any perspectives.}
+
+\item{patience}{If a web service call fails, it is repeated a further n times, with n being the value of patience.
+Must be set to a value between 0 and 3.}
 
 \item{resume}{If a previous call to this function has failed (and you think you have fixed the issue
 that caused the error), you can set resume=TRUE to recover any progress made up to that point. This

--- a/man/runBASwebservice_pho2sylCanonical.Rd
+++ b/man/runBASwebservice_pho2sylCanonical.Rd
@@ -5,8 +5,8 @@
 \title{Adds syllabified word labels to a word level that already contains canonical pronunciations.}
 \usage{
 runBASwebservice_pho2sylCanonical(handle, canoAttributeDefinitionName, language,
-  canoSylAttributeDefinitionName = "KAS", params = list(), resume = FALSE,
-  verbose = TRUE)
+  canoSylAttributeDefinitionName = "KAS", params = list(), patience = 0,
+  resume = FALSE, verbose = TRUE)
 }
 \arguments{
 \item{handle}{emuDB handle}
@@ -26,6 +26,9 @@ ensure that these parameters are compatible with the webservice API
 (see \url{https://clarin.phonetik.uni-muenchen.de/BASWebServices/services/help}).
 Some options accepted by the API (e.g. output format) cannot be set when calling a webservice from within emuR,
 and will be overridden.}
+
+\item{patience}{If a web service call fails, it is repeated a further n times, with n being the value of patience.
+Must be set to a value between 0 and 3.}
 
 \item{resume}{If a previous call to this function has failed (and you think you have fixed the issue
 that caused the error), you can set resume=TRUE to recover any progress made up to that point. This

--- a/man/runBASwebservice_pho2sylSegmental.Rd
+++ b/man/runBASwebservice_pho2sylSegmental.Rd
@@ -6,8 +6,8 @@
 \usage{
 runBASwebservice_pho2sylSegmental(handle, segmentAttributeDefinitionName,
   language, superLevel = NULL, sylAttributeDefinitionName = "MAS",
-  params = list(wsync = "yes"), perspective = "default", resume = FALSE,
-  verbose = TRUE)
+  params = list(wsync = "yes"), perspective = "default", patience = 0,
+  resume = FALSE, verbose = TRUE)
 }
 \arguments{
 \item{handle}{emuDB handle}
@@ -33,6 +33,9 @@ and will be overridden.}
 
 \item{perspective}{the webApp perspective that the new level will be added to.
 If NULL, the new level is not added to any perspectives.}
+
+\item{patience}{If a web service call fails, it is repeated a further n times, with n being the value of patience.
+Must be set to a value between 0 and 3.}
 
 \item{resume}{If a previous call to this function has failed (and you think you have fixed the issue
 that caused the error), you can set resume=TRUE to recover any progress made up to that point. This


### PR DESCRIPTION
BAS webservice functions now have a patience parameter, which can be set to a value between 0 and 3 (default 0). If a webservice call fails, it is repeated a further n times, before the function "gives up". This is meant to catch errors arising during short server outages at the BAS, or when webservices are re-deployed during a REST call.