### PR TITLE
Fix that allow for loading a database with a session but no bundles.

### DIFF
--- a/R/emuR-database.caching.R
+++ b/R/emuR-database.caching.R
@@ -26,7 +26,7 @@ update_cache <- function(emuDBhandle, verbose = TRUE){
   notUpdatedBundlesDBI = list_bundlesDBI(emuDBhandle)
   
   # add column to sessions to track if already stored
-  if(nrow(sessions) ==0){
+  if(nrow(sessions) ==0 || nrow(bundles) == 0){
     return()
   }
   


### PR DESCRIPTION
We need to allow loading of a database where we made a space for a session that we will fill later.
The old code tried to make a cache of the non-existing bundle when there was a session in the database. With this fix, caching is disabled when there are no bundles.