### PR TITLE
Fix to support also loading of databases with empty sessions

### DIFF
--- a/R/emuR-database.R
+++ b/R/emuR-database.R
@@ -1272,7 +1272,7 @@ load_emuDB <- function(databaseDir,
   sessions = list_sessions(dbHandle)
   bundles = list_bundles(dbHandle)
   # add column to sessions to track if already stored
-  if(nrow(sessions) != 0){
+  if(nrow(sessions) > 0 && nrow(bundles) > 0){
     sessions$stored = F
     
     # calculate bundle count


### PR DESCRIPTION
@MJochim  Sorry for not discovering that creating a database and then adding a session directory before having ever loaded it prevented the caching mechanism to work.

This simple fix disables caching if there are actually no bundles.